### PR TITLE
Fix primary key bug on subscription model

### DIFF
--- a/src/models/address.models.js
+++ b/src/models/address.models.js
@@ -58,7 +58,8 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN
     },
     aboweb_address_id: {
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      unique: true
     }
   })
 

--- a/src/models/subscription.models.js
+++ b/src/models/subscription.models.js
@@ -6,7 +6,8 @@ export default (sequelize, DataTypes) => {
       primaryKey: true
     },
     aboweb_subscription_id: {
-      type: DataTypes.INTEGER
+      type: DataTypes.INTEGER,
+      unique: true
     },
     aboweb_client_id: {
       type: DataTypes.INTEGER


### PR DESCRIPTION
Du coup le upsert était mal utilisé, le deuxième paramètre ne servait à rien. Sequelize se base sur la primary key et sur les contraintes d'unicité. 

Pour le client il n'y avait pas bug car il y a un index UNIQUE sur l'email et j'ai rajouté une contrainte d'unicité sur la clé d'aboweb.
  
⚠️ A retester avec les workers de prod au plus vite